### PR TITLE
Add retry with delay on some errors

### DIFF
--- a/iapi/client.go
+++ b/iapi/client.go
@@ -15,18 +15,18 @@ type Server struct {
 	Password           string
 	BaseURL            string
 	AllowUnverifiedSSL bool
-	retry_count        int
-	retry_delay        int
+	retryCount         int
+	retryDelay         int
 	httpClient         *http.Client
 }
 
-func New(username, password, url string, allowUnverifiedSSL bool, retry_count int, retry_delay int) (*Server, error) {
-	return &Server{username, password, url, allowUnverifiedSSL, retry_count, retry_delay, nil}, nil
+func New(username, password, url string, allowUnverifiedSSL bool, retryCount int, retryDelay int) (*Server, error) {
+	return &Server{username, password, url, allowUnverifiedSSL, retryCount, retryDelay, nil}, nil
 }
 
-func (server *Server) Config(username, password, url string, allowUnverifiedSSL bool, retry_count int, retry_delay int) (*Server, error) {
+func (server *Server) Config(username, password, url string, allowUnverifiedSSL bool, retryCount int, retryDelay int) (*Server, error) {
 	// TODO : Add code to verify parameters
-	return &Server{username, password, url, allowUnverifiedSSL, retry_count, retry_delay, nil}, nil
+	return &Server{username, password, url, allowUnverifiedSSL, retryCount, retryDelay, nil}, nil
 }
 
 func (server *Server) Connect() (error, int) {
@@ -60,11 +60,11 @@ func (server *Server) Connect() (error, int) {
 		if !((err != nil) || (response == nil)) {
 			break
 		}
-		if retries >= server.retry_count {
+		if retries >= server.retryCount {
 			break
 		}
 		retries += 1
-		time.Sleep(time.Duration(server.retry_delay) * time.Second)
+		time.Sleep(time.Duration(server.retryDelay) * time.Second)
 	}
 	if (err != nil) || (response == nil) {
 		server.httpClient = nil

--- a/iapi/client.go
+++ b/iapi/client.go
@@ -15,18 +15,18 @@ type Server struct {
 	Password           string
 	BaseURL            string
 	AllowUnverifiedSSL bool
-	retryCount         int
-	retryDelay         int
+	Retries            int
+	RetryDelay         time.Duration
 	httpClient         *http.Client
 }
 
-func New(username, password, url string, allowUnverifiedSSL bool, retryCount int, retryDelay int) (*Server, error) {
-	return &Server{username, password, url, allowUnverifiedSSL, retryCount, retryDelay, nil}, nil
+func New(username, password, url string, allowUnverifiedSSL bool, retries int, retryDelay time.Duration) (*Server, error) {
+	return &Server{username, password, url, allowUnverifiedSSL, retries, retryDelay, nil}, nil
 }
 
-func (server *Server) Config(username, password, url string, allowUnverifiedSSL bool, retryCount int, retryDelay int) (*Server, error) {
+func (server *Server) Config(username, password, url string, allowUnverifiedSSL bool, retries int, retryDelay time.Duration) (*Server, error) {
 	// TODO : Add code to verify parameters
-	return &Server{username, password, url, allowUnverifiedSSL, retryCount, retryDelay, nil}, nil
+	return &Server{username, password, url, allowUnverifiedSSL, retries, retryDelay, nil}, nil
 }
 
 func (server *Server) Connect() (error, int) {
@@ -60,11 +60,11 @@ func (server *Server) Connect() (error, int) {
 		if !((err != nil) || (response == nil || response.StatusCode == 503)) {
 			break
 		}
-		if retries >= server.retryCount {
+		if retries >= server.Retries {
 			break
 		}
-		retries += 1
-		time.Sleep(time.Duration(server.retryDelay) * time.Second)
+		retries++
+		time.Sleep(server.RetryDelay)
 	}
 	if (err != nil) || (response == nil || response.StatusCode == 503) {
 		server.httpClient = nil
@@ -111,11 +111,11 @@ func (server *Server) NewAPIRequest(method, APICall string, jsonString []byte) (
 			break
 		}
 
-		if retries >= server.retryCount {
+		if retries >= server.Retries {
 			break
 		}
-		retries += 1
-		time.Sleep(time.Duration(server.retryDelay) * time.Second)
+		retries++
+		time.Sleep(server.RetryDelay)
 	}
 
 	if doErr != nil {

--- a/iapi/client_test.go
+++ b/iapi/client_test.go
@@ -7,13 +7,13 @@ import (
 
 var ICINGA2_API_PASSWORD = os.Getenv("ICINGA2_API_PASSWORD")
 
-var Icinga2_Server = Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+var Icinga2_Server = Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, 0, 0, nil}
 
-//var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:5665/v1", true, nil}
+//var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:5665/v1", true, 0, 0, nil}
 
 func TestConnect(t *testing.T) {
 
-	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:5665/v1", true, nil}
+	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:5665/v1", true, 0, 0, nil}
 	Icinga2_Server.Connect()
 
 	if Icinga2_Server.httpClient == nil {
@@ -23,18 +23,21 @@ func TestConnect(t *testing.T) {
 
 func TestConnectServerUnavailable(t *testing.T) {
 
-	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:4665/v1", true, nil}
-	err := Icinga2_Server.Connect()
+	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:4665/v1", true, 5, 0, nil}
+	err, retries := Icinga2_Server.Connect()
 
 	if err == nil {
 		t.Errorf("Error : Did not get error connecting to unavailable server.")
+	}
+	if retries != 5 {
+		t.Errorf("Error : Did not get error connecting to unavailable server before 5 retries.")
 	}
 }
 
 func TestConnectWithBadCredential(t *testing.T) {
 
-	var Icinga2_Server = Server{"unknownUser", "unknownPW", "https://127.0.0.1:5665/v1", true, nil}
-	err := Icinga2_Server.Connect()
+	var Icinga2_Server = Server{"unknownUser", "unknownPW", "https://127.0.0.1:5665/v1", true, 0, 0, nil}
+	err, _ := Icinga2_Server.Connect()
 	if err != nil {
 		t.Errorf("Did not fail with bad credentials : %s", err)
 	}
@@ -51,7 +54,7 @@ func TestNewAPIRequest(t *testing.T) {
 
 func TestConnectServerBadURINoVersion(t *testing.T) {
 
-	var Icinga2_Server = Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", true, nil}
+	var Icinga2_Server = Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", true, 0, 0, nil}
 	result, _ := Icinga2_Server.NewAPIRequest("GET", "/status", nil)
 
 	if result.Code != 404 {

--- a/iapi/client_test.go
+++ b/iapi/client_test.go
@@ -52,6 +52,19 @@ func TestNewAPIRequest(t *testing.T) {
 	}
 }
 
+func TestNewAPIRequestServerUnavailable(t *testing.T) {
+
+	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:4665/v1", true, 5, 0, nil}
+	result, err := Icinga2_Server.NewAPIRequest("GET", "/status", nil)
+
+	if err == nil {
+		t.Errorf("Error : Did not get error connecting to unavailable server.")
+	}
+	if result.Retries != 5 {
+		t.Errorf("Error : Did not get error connecting to unavailable server before 5 retries.")
+	}
+}
+
 func TestConnectServerBadURINoVersion(t *testing.T) {
 
 	var Icinga2_Server = Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", true, 0, 0, nil}

--- a/iapi/hostgroups_test.go
+++ b/iapi/hostgroups_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestHostgroups(t *testing.T) {
-	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, 0, 0, nil}
 	t.Run("Create", func(t *testing.T) {
 		t.Run("Hostgroup", func(t *testing.T) {
 			name := "docker-servers"

--- a/iapi/notifications_test.go
+++ b/iapi/notifications_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestNotifications(t *testing.T) {
-	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, 0, 0, nil}
 	// testHostName := "notification-test-host"
 	// _, err := icingaServer.CreateHost(testHostName, "127.0.0.1", "hostalive", nil, nil, nil)
 	// if err != nil {

--- a/iapi/services_test.go
+++ b/iapi/services_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestServices(t *testing.T) {
-	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, 0, 0, nil}
 	testHostName := "c1-mysql-1"
 	_, err := icingaServer.CreateHost(testHostName, "127.0.0.1", "", "hostalive", nil, nil, nil)
 	if err != nil {

--- a/iapi/structs.go
+++ b/iapi/structs.go
@@ -98,6 +98,7 @@ type APIResult struct {
 	Status      string      `json:"Status"`
 	Code        int         `json:"Code"`
 	Results     interface{} `json:"results"`
+	Retries     int         `json:"Retries"`
 }
 
 // APIStatus stores the results of an Icinga2 API Status Call

--- a/iapi/structs.go
+++ b/iapi/structs.go
@@ -9,7 +9,7 @@ duplicate or near duplicate defintions of structs are being defined but can be r
 be in place to ensure everything still works.
 */
 
-//ServiceStruct stores service results
+// ServiceStruct stores service results
 type ServiceStruct struct {
 	Attrs ServiceAttrs `json:"attrs"`
 	Joins struct{}     `json:"joins"`
@@ -140,7 +140,7 @@ type UserAttrs struct {
 	Email string `json:"email"`
 }
 
-//NotificationStruct stores notification results
+// NotificationStruct stores notification results
 type NotificationStruct struct {
 	Attrs NotificationAttrs `json:"attrs"`
 	Joins struct{}          `json:"joins"`

--- a/iapi/users_test.go
+++ b/iapi/users_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestUser(t *testing.T) {
-	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, 0, 0, nil}
 	t.Run("Create", func(t *testing.T) {
 		t.Run("SimpleUser", func(t *testing.T) {
 			username := "test-user"


### PR DESCRIPTION
Implements retry with delay in case if Icinga2 server returns `503 Icinga is reloading` or low-level errors, like `Connection refused`.

Will be useful after package config management implemented - Icinga reloads on applying packages.