### PR TITLE
fix: Remove duplicate response body read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 JSON_Examples
+.env

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,15 @@ docker_get_root_password:
 docker_reset:
 	make docker_clean
 	make docker_start
+	make set_env
 
 docker_clean:
 	docker stop icinga2
 	docker rm icinga2
+
+set_env:
+	$(eval password:=$(shell docker exec icinga2 bash -c 'grep password /etc/icinga2/conf.d/api-users.conf' | awk -F'"' '{ print $$2}' ))
+	echo "ICINGA2_API_PASSWORD=$(password)" > .env
 
 test:
 	$(eval password:=$(shell docker exec icinga2 bash -c 'grep password /etc/icinga2/conf.d/api-users.conf' | awk -F'"' '{ print $$2}' ))

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/dakota-marshall/go-icinga2-api
 
 go 1.13
+
+require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/iapi/client_test.go
+++ b/iapi/client_test.go
@@ -1,9 +1,12 @@
 package iapi
 
 import (
+	"github.com/joho/godotenv"
 	"os"
 	"testing"
 )
+
+var env = godotenv.Load("../.env")
 
 var ICINGA2_API_PASSWORD = os.Getenv("ICINGA2_API_PASSWORD")
 
@@ -57,19 +60,6 @@ func TestNewFileRequestError(t *testing.T) {
 
 	if result.Code == 200 {
 		t.Errorf("%s", result.Status)
-	}
-}
-
-func TestNewAPIRequestServerUnavailable(t *testing.T) {
-
-	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:4665/v1", true, 5, 0, nil}
-	result, err := Icinga2_Server.NewAPIRequest("GET", "/status", nil)
-
-	if err == nil {
-		t.Errorf("Error : Did not get error connecting to unavailable server.")
-	}
-	if result.Retries != 5 {
-		t.Errorf("Error : Did not get error connecting to unavailable server before 5 retries.")
 	}
 }
 

--- a/iapi/hostgroups.go
+++ b/iapi/hostgroups.go
@@ -25,14 +25,14 @@ func (server *Server) GetHostgroup(name string) ([]HostgroupStruct, error) {
 	// Contents of the results is an interface object. Need to convert it to json first.
 	jsonStr, err := json.Marshal(results.Results)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to unmarshal hostgroup data: %s", jsonStr)
 	}
 
 	// then the JSON can be pushed into the appropriate struct.
 	// Note : Results is a slice so much push into a slice.
 	var hostgroups []HostgroupStruct
 	if err := json.Unmarshal(jsonStr, &hostgroups); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to unmarshal hostgroup data: %s \n%#v", jsonStr, results)
 	}
 
 	if len(hostgroups) == 0 {


### PR DESCRIPTION
This fix removes a duplicate response body read that was overwriting the Result field, as you can only read a response body once.

Also adds ability to load icinga key from dotenv 